### PR TITLE
[REVIEW] S3 Locking Support

### DIFF
--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -1036,10 +1036,11 @@ class ASVDb:
     def __uploadIfS3(self):
         # The name of the directory can be accessed from self.localS3Copy like
         # so: self.localS3Copy.name
-        for root, dirs, files in os.walk(self.localS3Copy.name):
-            for name in files:
-                self.s3Resource.Object(self.bucketName, self.bucketKey) \
-                    .upload_file(path.join(self.localS3Copy.name, root, name))
+        if self.__isS3URL(self.dbDir):
+            for root, dirs, files in os.walk(self.localS3Copy.name):
+                for name in files:
+                    self.s3Resource.Object(self.bucketName, self.bucketKey) \
+                        .upload_file(path.join(self.localS3Copy.name, root, name))
 
 
     def __removeLocalS3Copy(self):

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -1013,20 +1013,20 @@ class ASVDb:
 
         # If results isn't set, only download key files, else download key files and results
         if results == False:
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt))
                 .download_file(path.join(self.localS3Copy.name, confFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExtt))
                 .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, machineFileExt))
                 .download_file(path.join(self.localS3Copy.name, machineFileExt))    
         else:
             bucket = self.s3Resource.Bucket(self.bucketName)
             resultsPath = path.join(self.bucketKey, self.defaultResultsDirName, "*")
             localResultsPath = path.join(self.localS3Copy.name, results)
 
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt))
                 .download_file(path.join(self.localS3Copy.name, confFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExt))
                 .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
             
             for object in bucket.objects.filter(Prefix=resultsPath):

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -1035,7 +1035,7 @@ class ASVDb:
     def __uploadIfS3(self):
         # The name of the directory can be accessed from self.localS3Copy like
         # so: self.localS3Copy.name
-        for root, dirs, files in os.walk(self.localS3Copy.name)
+        for root, dirs, files in os.walk(self.localS3Copy.name):
             for name in files:
                 self.s3Resource.Object(self.bucketName, self.bucketKey) \
                     .upload_file(path.join(self.localS3Copy.name, root, name))

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -154,6 +154,7 @@ class ASVDb:
         self.projectName = projectName
         self.commitUrl = commitUrl
 
+        self.machineFileExt = path.join(self.defaultResultsDirName, "*", self.machineFileName)
         self.confFileExt = self.confFileName
         self.confFilePath = path.join(self.dbDir, self.confFileName)
         self.confVersion = self.defaultConfVersion
@@ -308,7 +309,7 @@ class ASVDb:
         self.__assertDbDirExists()
         try:
             self.__getLock(self.dbDir)
-            self.__downloadIfS3()
+            self.__downloadIfS3(results=True)
             retList = self.__readResults(filterByInfoObjs=filterInfoObjList)
 
         finally:
@@ -1007,13 +1008,29 @@ class ASVDb:
     ###########################################################################
     # S3 utilities
     ###########################################################################
-    def __downloadIfS3(self, fileExt):
+    def __downloadIfS3(self, results=False):
         self.localS3Copy = tempfile.TemporaryDirectory(suffix="asv")
 
-        # Download bucket contents and unpack in self.localS3Copy.name
-        self.__ensureDbDirExists()
-        self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
-            .download_file(path.join(self.localS3Copy.name, fileExt))
+        # If results isn't set, only download key files, else download key files and results
+        if results == False:
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+                .download_file(path.join(self.localS3Copy.name, confFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+                .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+                .download_file(path.join(self.localS3Copy.name, machineFileExt))    
+        else:
+            bucket = self.s3Resource.Bucket(self.bucketName)
+            resultsPath = path.join(self.bucketKey, self.defaultResultsDirName, "*")
+            localResultsPath = path.join(self.localS3Copy.name, results)
+
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+                .download_file(path.join(self.localS3Copy.name, confFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, fileExt))
+                .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
+            
+            for object in bucket.objects.filter(Prefix=resultsPath):
+                bucket.download_file(object.key, path.join(localResultsPath, object.key))
         
         # Set all the internal locations to point to the downloaded files:
         self.confFilePath = path.join(self.localS3Copy.name, self.confFileName)

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -1063,7 +1063,7 @@ class ASVDb:
         """
         Returns True if url is a S3 URL, False otherwise.
         """
-        if url.startswith("s3://"):
+        if url.startswith("s3:"):
             return True
 
         return False

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -170,7 +170,7 @@ class ASVDb:
         self.lockfileTimeout = 5  # seconds
 
         # S3-related attributes
-        if self.__isS3URL():
+        if self.__isS3URL(dbDir):
             self.s3Resource = boto3.resource("s3")
             self.bucketName = urlparse(self.dbDir, allow_fragments=False).netloc
             self.bucketKey = urlparse(self.dbDir, allow_fragments=False).path.lstrip('/')
@@ -483,10 +483,7 @@ class ASVDb:
         # FIXME: update for support S3 - this method should return True if
         # self.dbDir is a valid S3 URL or a valid path on disk.
         if self.__isS3URL(self.dbDir):
-            try:
-                self.s3Resource.Object(self.bucketName, self.bucketKey).load()
-            except botocore.exceptions.ClientError as e:
-                raise Exception(e)
+            self.s3Resource.Object(self.bucketName, self.bucketKey).load()
         else:
             if not(path.isdir(self.dbDir)):
                 raise FileNotFoundError(f"{self.dbDir} does not exist or is "
@@ -499,10 +496,7 @@ class ASVDb:
         # if it does not exist).  For a local file path, create it if it does
         # not exist, like already being done below.
         if self.__isS3URL(self.dbDir):
-            try:
-                self.s3Resource.Object(self.bucketName, self.bucketKey).load()
-            except botocore.exceptions.ClientError as e:
-                raise Exception(e)
+            self.s3Resource.Object(self.bucketName, self.bucketKey).load()
         else:
             if not(path.exists(self.dbDir)):
                 os.mkdir(self.dbDir)

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -983,10 +983,10 @@ class ASVDb:
             
     def __updateS3LockfileTimes(self):
         # Find lockfiles in S3 Bucket
-        response = self.s3Resource.list_objects_v2(
-            Bucket=self.bucketName,
-            Prefix=self.lockfilePrefix,
-            StartAfter=self.bucketKey
+        response = self.s3Resource.list_objects_v2( \
+            Bucket=self.bucketName, \
+            Prefix=self.lockfilePrefix, \
+            StartAfter=self.bucketKey \
         )["Contents"]
 
         return response
@@ -1007,20 +1007,20 @@ class ASVDb:
 
         # If results isn't set, only download key files, else download key files and results
         if results == False:
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt)) \
                 .download_file(path.join(self.localS3Copy.name, confFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExt)) \
                 .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, machineFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, machineFileExt)) \
                 .download_file(path.join(self.localS3Copy.name, machineFileExt))    
         else:
             bucket = self.s3Resource.Bucket(self.bucketName)
             resultsPath = path.join(self.bucketKey, self.defaultResultsDirName, "*")
             localResultsPath = path.join(self.localS3Copy.name, results)
 
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt)) \
                 .download_file(path.join(self.localS3Copy.name, confFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExt)) \
                 .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
             
             for object in bucket.objects.filter(Prefix=resultsPath):
@@ -1037,7 +1037,7 @@ class ASVDb:
         # so: self.localS3Copy.name
         for root, dirs, files in os.walk(self.localS3Copy.name)
             for name in files:
-                self.s3Resource.Object(self.bucketName, self.bucketKey)
+                self.s3Resource.Object(self.bucketName, self.bucketKey) \
                     .upload_file(path.join(self.localS3Copy.name, root, name))
 
 

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -957,10 +957,10 @@ class ASVDb:
                 debugCounter += 1
                 if self.debugPrint:
                     print(f"This lock file will be {thisLockfile} but other "
-                          f"locks present: {otherLocks}, waiting to try to "
+                          f"locks present: {otherLockfileTimes}, waiting to try to "
                           "lock again...")
                 time.sleep(2)
-                otherLockfileTimes = self.__updateOtherLockfileTimes()
+                otherLockfileTimes = self.__updateS3LockfileTimes()
                 if debugCounter >= 10:
                     raise Exception("Aborted due to possible infinite loop")
 
@@ -994,7 +994,7 @@ class ASVDb:
             Prefix=self.lockfilePrefix,
             StartAfter=self.bucketKey
         )["Contents"]
-        
+
         return response
 
 
@@ -1015,7 +1015,7 @@ class ASVDb:
         if results == False:
             self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, confFileExt))
                 .download_file(path.join(self.localS3Copy.name, confFileExt))
-            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExtt))
+            self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, benchmarksFileExt))
                 .download_file(path.join(self.localS3Copy.name, benchmarksFileExt))
             self.s3Resource.Object(self.bucketName, path.join(self.bucketKey, machineFileExt))
                 .download_file(path.join(self.localS3Copy.name, machineFileExt))    

--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -161,7 +161,7 @@ class ASVDb:
         self.resultsDirName = self.defaultResultsDirName
         self.resultsDirPath = path.join(self.dbDir, self.resultsDirName)
         self.htmlDirName = self.defaultHtmlDirName
-        self.benchmarksFileExt = path.join(self.defaultResultsDirName, self.benchmarksFiileName)
+        self.benchmarksFileExt = path.join(self.defaultResultsDirName, self.benchmarksFileName)
         self.benchmarksFilePath = path.join(self.resultsDirPath, self.benchmarksFileName)
 
         # Each ASVDb instance must have a unique lockfile name to identify other

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 
     run:
         - python
-
+        - boto3
 test:
     imports:
         - asvdb

--- a/tests/test_asvdb.py
+++ b/tests/test_asvdb.py
@@ -137,10 +137,10 @@ def test_asvDirDNE():
     tmpDir.cleanup()
 
 
-@pytest.mark.parametrize("asvDir", [tempfile.TemporaryDirectory(), "s3://test-bucket")] 
 def test_newBranch():
     from asvdb import ASVDb
 
+    asvDir = tempfile.TemporaryDirectory()
     repo = "somerepo"
     branch1 = "branch1"
     branch2 = "branch2"
@@ -180,12 +180,11 @@ def test_gitExtension():
     asvDir.cleanup()
 
 
-@pytest.mark.parametrize("asvDir", [tempfile.TemporaryDirectory(), "s3://test-bucket")]
+@pytest.mark.parametrize("asvDir", ["local", "s3"])
 def test_concurrency():
     from asvdb import ASVDb, BenchmarkInfo, BenchmarkResult
 
-    tmpDir = tempfile.TemporaryDirectory()
-    asvDirName = path.join(tmpDir.name, "dir_that_does_not_exist")
+    asvDirName = path.join(asvDir, "dir_that_does_not_exist")
     repo = "somerepo"
     branch1 = "branch1"
 
@@ -234,7 +233,7 @@ def test_concurrency():
 
     tmpDir.cleanup()
 
-
+@pytest.mark.parametrize("asvDir", ["local", "s3"])
 def test_concurrency_stress():
     from asvdb import ASVDb, BenchmarkInfo, BenchmarkResult
 

--- a/tests/test_asvdb.py
+++ b/tests/test_asvdb.py
@@ -350,10 +350,11 @@ def test_s3_concurrency_stress():
     threads = []
     allFuncNames = []
 
-    bInfo = BenchmarkInfo(machineName=machineName)
+    bInfo = BenchmarkInfo(machineName=machineName, cudaVer="Test", osType="Test", pythonVer="Test", commitHash="Test")
 
     for i in range(num):
         db = ASVDb(asvDirName, repo, [branch1])
+        db.debugPrint = True
         db.writeDelay=0.5
         dbs.append(db)
 
@@ -379,8 +380,7 @@ def test_s3_concurrency_stress():
     allFuncNamesCheck = [r.funcName for r in results[0][1]]
     assert sorted(allFuncNames) == sorted(allFuncNamesCheck)
 
-    db3.s3Resource.Bucket(db3.bucketName).objects.filter(Prefix="asv/").delete()
-
+    boto3.resource("s3").Bucket(bucketName).objects.filter(Prefix="asvdb/").delete()
 
 
 def test_read():

--- a/tests/test_asvdb.py
+++ b/tests/test_asvdb.py
@@ -5,7 +5,7 @@ import threading
 import time
 
 import pytest
-import boto
+import boto3
 
 datasetName = "dolphins.csv"
 algoRunResults = [('loadDataFile', 3.2228727098554373),

--- a/tests/test_asvdb.py
+++ b/tests/test_asvdb.py
@@ -137,11 +137,10 @@ def test_asvDirDNE():
     tmpDir.cleanup()
 
 
-
+@pytest.mark.parametrize("asvDir", [tempfile.TemporaryDirectory(), "s3://test-bucket")] 
 def test_newBranch():
     from asvdb import ASVDb
 
-    asvDir = tempfile.TemporaryDirectory()
     repo = "somerepo"
     branch1 = "branch1"
     branch2 = "branch2"
@@ -181,6 +180,7 @@ def test_gitExtension():
     asvDir.cleanup()
 
 
+@pytest.mark.parametrize("asvDir", [tempfile.TemporaryDirectory(), "s3://test-bucket")]
 def test_concurrency():
     from asvdb import ASVDb, BenchmarkInfo, BenchmarkResult
 


### PR DESCRIPTION
TODO:

- [x] Locking functionality
- [x] Unit Tests
- [x] Test Locally

I actually need to make a PR to `pytest-benchmark` to make it utilize `addResults` instead of `addResult` in the session finish function. This way its not making an enormous amount of API calls and locks for no reason.