### PR TITLE
Fix conda recipe

### DIFF
--- a/asvdb/__init__.py
+++ b/asvdb/__init__.py
@@ -6,5 +6,3 @@ from .asvdb import (
     BenchmarkResultKeys,
 )
 from . import utils
-
-__version__ = "0.4.1"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,25 +1,20 @@
 {% set version = load_setup_py_data().get('version') %}
-{% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 
 package:
     name: asvdb
     version: {{ version }}
 
 source:
-    #git_url: https://github.com/rapidsai/asvdb.git
     path: ..
 
 build:
-    number: {{ git_revision_count }}
-    script: python setup.py install
+    string: {{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    script: {{ PYTHON }} -m pip install . --no-deps
     noarch: python
 
 requirements:
-    build:
+    host:
         - python
-        - setuptools
-        - boto3
-        - botocore
 
     run:
         - python

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 from setuptools import setup
 
-import asvdb
-
 setup(name="asvdb",
-      version=asvdb.__version__,
+      version="0.4.1",
       packages=["asvdb"],
+      install_requires=["botocore", "boto3"],
       description='ASV "database" interface',
       entry_points={
           "console_scripts": [


### PR DESCRIPTION
Since `asvdb` recently imported the 3rd party packages `boto3` and `botocore`, our conda recipe's `load_setup_py_data` function was failing since `setup.py` imported `asvdb`, which in turn imported `boto3` and `botocore`. This caused a build error since `boto3` and `botocore` weren't installed on the system.

This PR fixes that issue by moving the package version from `asvdb/__init__.py` to `setup.py`.

Additionally, it removes the duplicated runtime dependencies from the requirements section and makes some small changes to the build package name.