### PR TITLE
Fixed bug preventing parameterized results from being added in a random order

### DIFF
--- a/asvdb/asvdb.py
+++ b/asvdb/asvdb.py
@@ -687,6 +687,21 @@ class ASVDb:
         existingParamValuesList = resultDict.setdefault("params", [])
         existingResultValueList = resultDict.setdefault("result", [])
 
+        # ASV uses the cartesian product of the param values for looking up the
+        # result for a particular combination of param values.  For example:
+        # "params": [["a"], ["b", "c"], ["d", "e"]] results in: [("a", "b",
+        # "d"), ("a", "b", "e"), ("a", "c", "d"), ("a", "c", "e")] and each
+        # combination of param values has a result, with the results for the
+        # corresponding param values in the same order.  If a result for a set
+        # of param values DNE, use None.
+
+        # store existing results in map based on cartesian product of all
+        # current params.
+        paramsCartProd = list(itertools.product(*existingParamValuesList))
+        # Assume there is an equal number of results for cartProd values
+        # (some will be None)
+        paramsResultMap = dict(zip(paramsCartProd, existingResultValueList))
+
         # FIXME: dont assume these are ordered properly (ie. the same way as
         # defined in benchmarks.json)
         newResultParamValues = tuple(v for (_, v) in benchmarkResult.argNameValuePairs)
@@ -703,21 +718,6 @@ class ASVDb:
             for i in range(numExistingParamValues):
                 if newResultParamValues[i] not in existingParamValuesList[i]:
                     existingParamValuesList[i].append(newResultParamValues[i])
-
-            # ASV uses the cartesian product of the param values for looking up
-            # the result for a particular combination of param values.  For
-            # example: "params": [["a"], ["b", "c"], ["d", "e"]] results in:
-            # [("a", "b", "d"), ("a", "b", "e"), ("a", "c", "d"), ("a", "c",
-            # "e")] and each combination of param values has a result, with the
-            # results for the corresponding param values in the same order.  If
-            # a result for a set of param values DNE, use None.
-
-            # store existing results in map based on cartesian product of all
-            # current params.
-            paramsCartProd = list(itertools.product(*existingParamValuesList))
-            # Assume there is an equal number of results for cartProd values
-            # (some will be None)
-            paramsResultMap = dict(zip(paramsCartProd, existingResultValueList))
 
             # Add the new result
             paramsResultMap[newResultParamValues] = benchmarkResult.result
@@ -952,14 +952,14 @@ class ASVDb:
 
             while otherLockfileTimes[1] != 0:
                 if self.debugPrint:
-                    lockfileList = [] 
+                    lockfileList = []
                     for each in otherLockfileTimes[0]:
                         lockfileList.append(each.key)
 
                     print(f"This lock file will be {thisLockfile} but other "
                           f"locks present: {lockfileList}, waiting to try to "
                           "lock again...")
-                
+
                 time.sleep(1)
                 otherLockfileTimes = self.__updateS3LockfileTimes()
 
@@ -967,14 +967,14 @@ class ASVDb:
             if self.debugPrint:
                 print(f"All clear, setting lock {thisLockfile}")
             self.s3Resource.Object(self.bucketName, thisLockfile).put()
-            
+
             #Give S3 time to see the new lock
             time.sleep(1)
 
             # Check for a race condition where another lock could have been created
             # while creating the lock for this instance.
             otherLockfileTimes = self.__updateS3LockfileTimes()
-            
+
             if otherLockfileTimes[1] != 0:
                 self.__releaseS3Lock()
                 randTime = (int(30 * random.random()) + 5) + random.random()
@@ -987,7 +987,7 @@ class ASVDb:
 
             i += 1
 
-            
+
     def __updateS3LockfileTimes(self):
         # Find lockfiles in S3 Bucket
         response = self.s3Resource.Bucket(self.bucketName).objects \
@@ -1063,7 +1063,7 @@ class ASVDb:
             try:
                 resultsBucketPath = path.join(self.bucketKey, self.defaultResultsDirName)
                 resultsLocalPath = path.join(self.localS3Copy.name, self.defaultResultsDirName)
-                
+
                 # Loop over ASV results folder and download everything.
                 # objectExt represents the file extension starting from the base resultsBucketPath
                 # For example: resultsBucketPath = "asvdb/results"
@@ -1074,12 +1074,12 @@ class ASVDb:
                     if len(objectExt.split("/")) > 1:
                         os.makedirs(path.join(resultsLocalPath, objectExt.split("/")[0]), exist_ok=True)
                     bucket.download_file(bucketObj.key, path.join(resultsLocalPath, objectExt))
-            
+
             except exceptions.ClientError as e:
                 err = "Not Found"
                 if err not in e.response["Error"]["Message"]:
                     raise e
-        
+
         # Set all the internal locations to point to the downloaded files:
         self.confFilePath = path.join(self.localS3Copy.name, self.confFileName)
         self.resultsDirPath = path.join(self.localS3Copy.name, self.resultsDirName)
@@ -1094,7 +1094,7 @@ class ASVDb:
             for name in files:
                 self.s3Resource.Bucket(self.bucketName) \
                     .upload_file(path.join(base, ext, name), path.join(self.bucketKey, ext, name))
-            
+
             # Call upload again for each folder
             if len(dirs) != 0:
                 for folder in dirs:
@@ -1105,7 +1105,7 @@ class ASVDb:
             recursiveUpload(self.localS3Copy.name)
             # Give S3 time to see the new uploads before releasing lock
             time.sleep(1)
-                
+
 
     def __removeLocalS3Copy(self):
         if not self.__isS3URL(self.dbDir):

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,9 @@ set -e
 UPLOAD_FILE=`conda build ./conda --output`
 UPLOAD_FILES=$(echo ${UPLOAD_FILE}|sed -e 's/\-py[0-9][0-9]/\-py36/')
 UPLOAD_FILES="${UPLOAD_FILES} $(echo ${UPLOAD_FILE}|sed -e 's/\-py[0-9][0-9]/\-py37/')"
+UPLOAD_FILES="${UPLOAD_FILES} $(echo ${UPLOAD_FILE}|sed -e 's/\-py[0-9][0-9]/\-py38/')"
 
-conda build --variants="{python: [3.6, 3.7]}" ./conda
+conda build --variants="{python: [3.6, 3.7, 3.8]}" ./conda
 if [ "$1" = "--publish" ]; then
     anaconda upload ${UPLOAD_FILES}
 fi

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name="asvdb",
-      version="0.4.1",
+      version="0.4.2",
       packages=["asvdb"],
       install_requires=["botocore", "boto3"],
       description='ASV "database" interface',


### PR DESCRIPTION
The code assumed parameterized results were added in the same order as the computed Cartesian product of the param values.  If results for param combinations were added in a different order, some results were replaced by `null` in the JSON.
For example, the code previously expected these results to be added in this order:
```
{'funcName': 'bfs', 'result': 0.012093378696590662, 'argNameValuePairs': [('scale', 10), ('ngpus', 1)]},
{'funcName': 'bfs', 'result': 0.19485003012232482, 'argNameValuePairs': [('scale', 10), ('ngpus', 2)]},
{'funcName': 'bfs', 'result': 0.22938291303580627, 'argNameValuePairs': [('scale', 10), ('ngpus', 4)]},
{'funcName': 'bfs', 'result': 0.30646290094591677, 'argNameValuePairs': [('scale', 10), ('ngpus', 8)]},
{'funcName': 'bfs', 'result': 0.01159052224829793, 'argNameValuePairs': [('scale', 11), ('ngpus', 1)]},
{'funcName': 'bfs', 'result': 0.18941782205365598, 'argNameValuePairs': [('scale', 11), ('ngpus', 2)]},
{'funcName': 'bfs', 'result': 0.23198354698251933, 'argNameValuePairs': [('scale', 11), ('ngpus', 4)]},
{'funcName': 'bfs', 'result': 0.3148591748904437, 'argNameValuePairs': [('scale', 11), ('ngpus', 8)]}
```
(notice all scale 10 results first, then scale 11).  If added in a different order, some result values get replaced with `null`.

A new test was also added and confirmed to fail prior to the bug fix. The bug fix was made, then the test passed.

For conda, the version number was updated and python 3.8 was added to the list of build variants.
